### PR TITLE
Include the pb_decode.h header

### DIFF
--- a/src/pb.h
+++ b/src/pb.h
@@ -1,2 +1,3 @@
 #include "proto/pb.h"
 #include "proto/pb_encode.h"
+#include "proto/pb_decode.h"


### PR DESCRIPTION
So that it's available when using the library for reading decoding protobufs.